### PR TITLE
Bug fixes for wrong logging causing failure

### DIFF
--- a/src/main/java/org/bitsquad/warzone/gameengine/phase/StartupMapEditing.java
+++ b/src/main/java/org/bitsquad/warzone/gameengine/phase/StartupMapEditing.java
@@ -70,7 +70,7 @@ public class StartupMapEditing extends Startup {
         if (p_addIds != null) {
             for (int i = 0; i < p_addIds.length; i += 2) {
                 this.d_gameEngine.getGameMap().addNeighbor(p_addIds[i], p_addIds[i + 1]);
-                LogEntryBuffer.getInstance().log("Neighbor " + p_removeIds[i] + " and " + p_removeIds[i + 1] + " added");
+                LogEntryBuffer.getInstance().log("Neighbor " + p_addIds[i] + " and " + p_addIds[i + 1] + " added");
             }
         }
         if (p_removeIds != null) {


### PR DESCRIPTION
In StartupMapEdit, logging was incorrectly using a null array. Raising an exception. Fixed.